### PR TITLE
Remove invisible bug icon

### DIFF
--- a/powa/templates/layout.html
+++ b/powa/templates/layout.html
@@ -88,7 +88,7 @@
         </div>
         <div class="large-6 columns">
           <ul class="inline-list right">
-            <li><a href="https://github.com/powa-team/powa-web/issues"><i class="fa fa-bug"></i>Report a bug</a></li>
+            <li><a href="https://github.com/powa-team/powa-web/issues">Report a bug</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
Fixes #35

We don't use fontawesome and unfortunately there's no bug icon in foundation icons set.
Let's remove it.
