### PR TITLE
Fix disk hit ratio

### DIFF
--- a/powa/query.py
+++ b/powa/query.py
@@ -127,7 +127,7 @@ class QueryOverviewMetricGroup(MetricGroupDef):
                         .label("kcache_hitblocks"))
             sys_hitratio = (cast(sys_hits, Numeric) * 100 /
                             mulblock(total_blocks))
-            disk_hit_ratio = (kc.reads /
+            disk_hit_ratio = (kc.reads * 100 /
                               mulblock(total_blocks))
             total_time = greatest(c.runtime, 1);
             # Rusage can return values > real time due to sampling bias


### PR DESCRIPTION
This PR fix disk hit ratio chart (missing `* 100` factor)

Before:
![image](https://user-images.githubusercontent.com/6862220/53300481-3042dd80-3848-11e9-8a4b-d655b809e1a8.png)

After:
![image](https://user-images.githubusercontent.com/6862220/53300487-3a64dc00-3848-11e9-9e31-5e35cc840024.png)
