### PR TITLE
Limit max version of sqlalchemy and tornado

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2
-sqlalchemy>=0.8.0
-tornado>=2.0
+sqlalchemy>=0.8.0,<1.3
+tornado>=2.0,<6


### PR DESCRIPTION
- Graphs won't render in SQLAlchemy 1.3.x

- WSGIAdapter has been deprecated in tornado 5.1 and [removed in 6.0](https://www.tornadoweb.org/en/stable/releases/v6.0.0.html?highlight=WSGIAdapter). See related message at https://groups.google.com/forum/#!topic/python-tornado/9VUOZc8SIC0

This is a stopgap measure and the incompatibilities should probably be addressed in the codebase. It may have consequences on ascendant compatibility, however.

The documentation website should also be updated at https://github.com/powa-team/powa/blob/master/docs/powa-web/index.rst