### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-3.2.1(WIP):
+3.2.1:
   - Add pg_wait_sampling in the config extension list (Julien Rouhaud, thanks
     to Adrien Nayrat for the report)
   - Don't try to detect if a hypotetical index would be used if no suitable


### PR DESCRIPTION
Hello Powa-team,

It would be nice having a 3.2.1 release version that solve some already corrected problems.
That would help people running Powa in production environment while the version 4 is in beta.

Cordialement,