### PR TITLE
Use alias instead of hostname:port

### DIFF
--- a/powa/framework.py
+++ b/powa/framework.py
@@ -149,10 +149,11 @@ class BaseHandler(RequestHandler):
             return self.current_connection
         else:
             return self.execute("""
-                                   SELECT hostname || ':' || port
-                                   FROM powa_servers
-                                   WHERE id = %(srvid)s
-                                   """, params={'srvid': int(srvid)}
+                                SELECT COALESCE(alias,
+                                                hostname || ':' || port)
+                                FROM powa_servers
+                                WHERE id = %(srvid)s
+                                """, params={'srvid': int(srvid)}
                                 ).scalar()
 
     @property


### PR DESCRIPTION
~~Remove unnecessary check for srvid=0. Alias is automatically added during first insert in power-archivist.~~ => Only change the query to use alias instead of hostname:port 