### PR TITLE
Prevent footer to be too wide

### DIFF
--- a/powa/templates/layout.html
+++ b/powa/templates/layout.html
@@ -104,7 +104,7 @@
       {% module Messages() %}
     </div>
     {% block content %} {% end %}
-    <footer class="row full-width" >
+    <footer>
       <div class="large-12 columns" >
         <div class="row hide-for-small">
           <div class="large-6 columns">


### PR DESCRIPTION
Avoids horizontal scroll bar to appear in most cases

Please note that it can be seen in the configuration page easily. There's still a problem with the horizontal scroll bar in some other pages. I'm currently diggin into it.