### PR TITLE
Fix global databases metrics query

### DIFF
--- a/powa/server.py
+++ b/powa/server.py
@@ -237,7 +237,8 @@ class GlobalDatabasesMetricGroup(MetricGroupDef):
                          nvcsws, nivcsws])
             from_clause = from_clause.join(
                 kcache_query,
-                kcache_query.c.ts == c.ts)
+                and_(kcache_query.c.dbid == c.dbid,
+                     kcache_query.c.ts == c.ts))
 
         return (select(cols)
                 .select_from(from_clause)


### PR DESCRIPTION
The missing join condition resulted in incorrect numbers of queries, runtime, page faults, context switches, and block access per second.

The above numbers were N times bigger, where N is the number of databases in the cluster with some registered activity.