### PR TITLE
Remove useless string formatting

### DIFF
--- a/powa/collector.py
+++ b/powa/collector.py
@@ -21,8 +21,7 @@ class CollectorServerDetail(MetricGroupDef):
         sql = """SELECT *
             FROM powa_servers s
             JOIN powa_snapshot_metas m ON m.srvid = s.id
-            WHERE s.id = %(server)s
-        """ % {'server': server}
+            WHERE s.id = %(server)s"""
 
         row = self.execute(sql, params={'server': server}).fetchone()
 


### PR DESCRIPTION
Potentially it could lead to sql injection, although chances that it will be exploited are close to zero due to the url format validation.