### PR TITLE
Fix generated where clause on c.calls.

### DIFF
--- a/powa/database.py
+++ b/powa/database.py
@@ -152,7 +152,7 @@ class DatabaseOverviewMetricGroup(MetricGroupDef):
 
         return (select(cols)
                 .select_from(from_clause)
-                .where(c.calls is not None)
+                .where(c.calls != '0')
                 .group_by(c.srvid, c.ts, bs, c.mesure_interval)
                 .order_by(c.ts)
                 .params(samples=100))

--- a/powa/query.py
+++ b/powa/query.py
@@ -237,7 +237,7 @@ class QueryOverviewMetricGroup(MetricGroupDef):
 
         return (select(cols)
                 .select_from(from_clause)
-                .where(c.calls != None)
+                .where(c.calls != '0')
                 .group_by(c.ts, block_size.c.block_size, c.mesure_interval)
                 .order_by(c.ts)
                 .params(samples=100))

--- a/powa/server.py
+++ b/powa/server.py
@@ -242,7 +242,7 @@ class GlobalDatabasesMetricGroup(MetricGroupDef):
 
         return (select(cols)
                 .select_from(from_clause)
-                .where(c.calls is not None)
+                .where(c.calls != '0')
                 .group_by(c.srvid, c.ts, bs, c.mesure_interval)
                 .order_by(c.ts)
                 .params(samples=100))


### PR DESCRIPTION
The goal was to remove zero values.
However "c.calls is not None" was translated to "WHERE true"
and "c.calls != None" to "WHERE c.calls IS NOT NULL".

Fix #102 