### PR TITLE
Last mesure_interval must be ignored.

### DIFF
--- a/powa/database.py
+++ b/powa/database.py
@@ -293,6 +293,7 @@ class DatabaseAllRelMetricGroup(MetricGroupDef):
         return (select(cols)
                 .select_from(from_clause)
                 .where(c.datname == bindparam("database"))
+                .where(c.mesure_interval != '0')
                 .group_by(c.srvid, c.ts, c.mesure_interval)
                 .order_by(c.ts)
                 .params(samples=100))

--- a/powa/server.py
+++ b/powa/server.py
@@ -406,6 +406,7 @@ class GlobalBgwriterMetricGroup(MetricGroupDef):
 
         return (select(cols)
                 .select_from(from_clause)
+                .where(c.mesure_interval != 0)
                 .group_by(c.srvid, c.ts, bs, c.mesure_interval)
                 .order_by(c.ts)
                 .params(samples=100))
@@ -471,6 +472,7 @@ class GlobalAllRelMetricGroup(MetricGroupDef):
 
         return (select(cols)
                 .select_from(from_clause)
+                .where(c.mesure_interval != '0')
                 .group_by(c.srvid, c.ts, c.mesure_interval)
                 .order_by(c.ts)
                 .params(samples=100))


### PR DESCRIPTION
The last value computed is equal to 0 and can break graph:
Before:
![image](https://user-images.githubusercontent.com/6862220/86125436-f25d6580-badc-11ea-879e-13641a697830.png)


After:
![image](https://user-images.githubusercontent.com/6862220/86125497-0c974380-badd-11ea-9df4-5dc1d43cc5d3.png)


