### PR TITLE
Avoid cartesian product in predicate view

### DIFF
--- a/powa/qual.py
+++ b/powa/qual.py
@@ -86,7 +86,7 @@ class QualDetail(ContentWidget):
         stmt = (stmt.select()
                 .where((c.qualid == bindparam("qualid")))
                 .where(stmt.c.occurences > 0)
-                .column((c.queryid == bindparam("query")).label("is_my_query")))
+                .column((stmt.c.queryid == bindparam("query")).label("is_my_query")))
         quals = list(self.execute(
             stmt,
             params={"server": server,


### PR DESCRIPTION
`stmt` was missing and leads sqlalchemy to add a join on powa_statement without filtering clause.
It generates a cartesian product and python eating all memory.

Thanks @rdunklau for the fix!