### PR TITLE
Fixed links to documentation

### DIFF
--- a/powa/dashboards.py
+++ b/powa/dashboards.py
@@ -567,6 +567,7 @@ class DashboardPage(object):
     datasources = []
     parent = None
     timeline = None
+    docs_stats_url = 'https://powa.readthedocs.io/en/latest/components/stats_extensions/'
 
     @classmethod
     def url_specs(cls, url_prefix):

--- a/powa/database.py
+++ b/powa/database.py
@@ -467,7 +467,7 @@ class DatabaseOverview(DashboardPage):
             block_graph.color_scheme = ['#cb513a', '#65b9ac', '#73c03a']
 
             sys_graphs = [Graph("System resources (events per sec)",
-                                url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_stat_kcache.html",
+                                url=self.docs_stats_url + "pg_stat_kcache.html",
                                 metrics=[DatabaseOverviewMetricGroup.majflts,
                                          DatabaseOverviewMetricGroup.minflts,
                                          # DatabaseOverviewMetricGroup.nswaps,
@@ -503,7 +503,7 @@ class DatabaseOverview(DashboardPage):
 
             graphs_dash.append(Dashboard("Wait Events",
                 [[Graph("Wait Events (per second)",
-                        url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_wait_sampling.html",
+                        url=self.docs_stats_url + "pg_wait_sampling.html",
                         metrics=metrics)]]))
 
         self._dashboard.widgets.extend(
@@ -540,7 +540,7 @@ class DatabaseOverview(DashboardPage):
         if self.has_extension(self.path_args[0], "pg_wait_sampling"):
             self._dashboard.widgets.extend([[
                 Grid("Wait events for all queries",
-                     url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_wait_sampling.html",
+                     url=self.docs_stats_url + "pg_wait_sampling.html",
                      columns=[{
                        "name": "query",
                        "label": "Query",

--- a/powa/query.py
+++ b/powa/query.py
@@ -605,7 +605,7 @@ class QueryOverview(DashboardPage):
         iodash = Dashboard("IO",
             [[hit_ratio_graph,
               Graph("Read / Write time",
-                    url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_stat_kcache.html",
+                    url=self.docs_stats_url + "pg_stat_kcache.html",
                     metrics=[QueryOverviewMetricGroup.blk_read_time,
                              QueryOverviewMetricGroup.blk_write_time])]])
         dashes.append(iodash)
@@ -613,11 +613,11 @@ class QueryOverview(DashboardPage):
         if self.has_extension(self.path_args[0], "pg_stat_kcache"):
             iodash.widgets.extend([[
                 Graph("Physical block (in Bps)",
-                      url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_stat_kcache.html",
+                      url=self.docs_stats_url + "pg_stat_kcache.html",
                       metrics=[QueryOverviewMetricGroup.reads,
                                QueryOverviewMetricGroup.writes]),
                 Graph("CPU Time repartition",
-                      url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_stat_kcache.html",
+                      url=self.docs_stats_url + "pg_stat_kcache.html",
                       metrics=[QueryOverviewMetricGroup.user_time,
                                QueryOverviewMetricGroup.system_time,
                                QueryOverviewMetricGroup.other_time],
@@ -630,7 +630,7 @@ class QueryOverview(DashboardPage):
                 QueryOverviewMetricGroup.disk_hit_ratio)
 
             sys_graphs = [Graph("System resources (events per sec)",
-                                url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_stat_kcache.html",
+                                url=self.docs_stats_url + "pg_stat_kcache.html",
                                 metrics=[QueryOverviewMetricGroup.majflts,
                                          QueryOverviewMetricGroup.minflts,
                                          # QueryOverviewMetricGroup.nswaps,
@@ -664,10 +664,10 @@ class QueryOverview(DashboardPage):
                          WaitsQueryOverviewMetricGroup.count_io]
             dashes.append(Dashboard("Wait Events",
                 [[Graph("Wait Events (per second)",
-                        url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_wait_sampling.html",
+                        url=self.docs_stats_url + "pg_wait_sampling.html",
                         metrics=metrics),
                   Grid("Wait events summary",
-                        url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_wait_sampling.html",
+                       url=self.docs_stats_url + "pg_wait_sampling.html",
                        columns=[{
                            "name": "event_type",
                            "label": "Event Type",

--- a/powa/server.py
+++ b/powa/server.py
@@ -552,7 +552,7 @@ class ServerOverview(DashboardPage):
             block_graph.color_scheme = ['#cb513a', '#65b9ac', '#73c03a']
 
             sys_graphs = [Graph("System resources (events per sec)",
-                                url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_stat_kcache.html",
+                                url=self.docs_stats_url + "pg_stat_kcache.html",
                                 metrics=[GlobalDatabasesMetricGroup.majflts,
                                          GlobalDatabasesMetricGroup.minflts,
                                          # GlobalDatabasesMetricGroup.nswaps,
@@ -590,7 +590,7 @@ class ServerOverview(DashboardPage):
 
             graphs_dash.append(Dashboard("Wait Events",
                 [[Graph("Wait Events (per second)",
-                        url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_wait_sampling.html",
+                        url=self.docs_stats_url + "pg_wait_sampling.html",
                         metrics=metrics)]]))
 
         dashes = [graphs,
@@ -604,7 +604,7 @@ class ServerOverview(DashboardPage):
 
         if self.has_extension(self.path_args[0], "pg_wait_sampling"):
             dashes.append([Grid("Wait events for all databases",
-                                url="https://powa.readthedocs.io/en/latest/stats_extensions/pg_wait_sampling.html",
+                                url=self.docs_stats_url + "pg_wait_sampling.html",
                                 columns=[{
                                     "name": "datname",
                                     "label": "Database",


### PR DESCRIPTION
Currently all link in powa-web to the documentation are broken and leading in a 404.

*Example:*
https://powa.readthedocs.io/en/latest/stats_extensions/pg_wait_sampling.html

*Should be:*
https://powa.readthedocs.io/en/latest/components/stats_extensions/pg_wait_sampling.html