### PR TITLE
Changed some "number" table columns to "integer"

### DIFF
--- a/powa/database.py
+++ b/powa/database.py
@@ -305,7 +305,7 @@ class ByQueryMetricGroup(MetricGroupDef):
     xaxis = "queryid"
     axis_type = "category"
     data_url = r"/server/(\d+)/metrics/database_all_queries/([^\/]+)/"
-    calls = MetricDef(label="#", type="number")
+    calls = MetricDef(label="#", type="integer")
     runtime = MetricDef(label="Time", type="duration", direction="descending")
     avg_runtime = MetricDef(label="Avg time", type="duration")
     blks_read_time = MetricDef(label="Read", type="duration")
@@ -365,7 +365,7 @@ class ByQueryWaitSamplingMetricGroup(MetricGroupDef):
     xaxis = "query"
     axis_type = "category"
     data_url = r"/server/(\d+)/metrics/database_all_queries_waits/([^\/]+)/"
-    counts = MetricDef(label="# of events", type="number",
+    counts = MetricDef(label="# of events", type="integer",
                        direction="descending")
 
     @property

--- a/powa/query.py
+++ b/powa/query.py
@@ -445,7 +445,7 @@ class WaitSamplingList(MetricGroupDef):
     xaxis = "event"
     axis_type = "category"
     data_url = r"/server/(\d+)/metrics/database/([^\/]+)/query/(-?\d+)/wait_events"
-    counts = MetricDef(label="# of events", type="number",
+    counts = MetricDef(label="# of events", type="integer",
                        direction="descending")
 
     def prepare(self):

--- a/powa/server.py
+++ b/powa/server.py
@@ -44,7 +44,7 @@ class ByDatabaseMetricGroup(MetricGroupDef):
     xaxis = "datname"
     data_url = r"/server/(\d+)/metrics/by_databases/"
     axis_type = "category"
-    calls = MetricDef(label="#Calls", type="number", direction="descending")
+    calls = MetricDef(label="#Calls", type="integer", direction="descending")
     runtime = MetricDef(label="Runtime", type="duration")
     avg_runtime = MetricDef(label="Avg runtime", type="duration")
     shared_blks_read = MetricDef(label="Blocks read", type="size")
@@ -101,7 +101,7 @@ class ByDatabaseWaitSamplingMetricGroup(MetricGroupDef):
     data_url = r"/server/(\d+)/metrics/wait_event_by_databases/"
     axis_type = "category"
     counts = MetricDef(label="# of events",
-                       type="number", direction="descending")
+                       type="integer", direction="descending")
 
     @property
     def query(self):


### PR DESCRIPTION
Just a very small UI change...maybe it's just me, but I prefer to strip the decimal places for plain integers, like amouts/counts.

Example from the demo, where you can see the ".00" in the "#" column:
![demo](https://user-images.githubusercontent.com/1894271/86818721-0417ad80-c087-11ea-8217-52e8ae9aec9f.png)

Would then look like:
![after_main](https://user-images.githubusercontent.com/1894271/86818834-27425d00-c087-11ea-92db-a4ef3d8238eb.png)

Internally the IntegerCell is exending the NumberCell and just setting decimals to 0