### PR TITLE
WIP: Re-implemented multiple scales for 2 y-axis

### DIFF
--- a/powa/static/js/config.js
+++ b/powa/static/js/config.js
@@ -19,7 +19,6 @@ require.config({
     underscore: "../bower_components/underscore/underscore",
     backgrid: "../bower_components/backgrid/lib/backgrid",
     spin: "../bower_components/spin.js/spin",
-    twix: "../bower_components/twix/bin/twix",
     "backgrid-filter": "../bower_components/backgrid-filter/backgrid-filter",
     "backgrid-paginator": "../bower_components/backgrid-paginator/backgrid-paginator",
     "backbone-pageable": "../bower_components/backbone-pageable/lib/backbone-pageable",

--- a/powa/static/js/powa/views/ContentView.js
+++ b/powa/static/js/powa/views/ContentView.js
@@ -2,9 +2,8 @@ define([
         'powa/views/WidgetView',
         'powa/models/Content',
         'highlight',
-        'moment',
-        'powa/utils/duration'],
-function(WidgetView, Content, highlight, moment, duration){
+        'moment'],
+function(WidgetView, Content, highlight, moment){
     return WidgetView.extend({
         model: Content,
         typname: "content",

--- a/powa/static/js/powa/views/DashboardView.js
+++ b/powa/static/js/powa/views/DashboardView.js
@@ -3,11 +3,7 @@ define([
     'foundation/foundation.equalizer',
     'backbone',
     'powa/views/WidgetView',
-    'foundation-daterangepicker',
-    'moment',
-    'powa/utils/timeurls'
-], function(jquery, foundation, Backbone, WidgetView, daterangepicker,
-    moment, timeurls){
+], function(jquery, foundation, Backbone, WidgetView){
     return WidgetView.extend({
         tagName: "div",
         typname: "dashboard",

--- a/powa/static/js/powa/views/GraphView.js
+++ b/powa/static/js/powa/views/GraphView.js
@@ -210,7 +210,6 @@ define([
                if(this.graph){
                 this.graph.configure({width: this.$graph_elem.parent().innerWidth()});
                 _.each(this.y_axes, function(axis){
-                    var width = axis.orientation === "left" ? 0 : this.$el.innerWidth();
                     axis.setSize({height: this.graph.height + 4, auto: true});
                 }, this);
                 this.graph.render();

--- a/powa/static/js/powa/views/GraphView.js
+++ b/powa/static/js/powa/views/GraphView.js
@@ -74,29 +74,22 @@ define([
                 };
             },
 
-            updateScales: function(series){
-                var self = this;
+            updateScales: function(){
                 $.each(this.y_axes, function(key, axis){
-                    return;
-                    var unit = key;
-                    var ymin = +Infinity,
-                        ymax = -Infinity;
+                    var ymax = -Infinity;
                     axis.scale = d3.scale.linear();
                     var all_series = [];
                     _.each(this.graph.series, function(serie){
                         var metric = serie.metric;
                         if(metric.get("type") === key){
                             _.each(serie.data, function(datum){
-                                ymin = Math.min(datum.y, ymin);
                                 ymax = Math.max(datum.y, ymax);
                                 serie.scale = axis.scale;
                                 all_series.push(serie);
                             });
-                        };
+                        }
                     });
-                    ymin = 0.8 * ymin;
-                    ymax = 1.2 * ymax;
-                    axis.scale = axis.scale.domain([ymin, ymax]).range([0, 1]);
+                    axis.scale = axis.scale.domain([0, ymax]).range([0, 1]);
                     _.each(all_series, function(serie){
                         serie.scale = axis.scale;
                     });
@@ -159,7 +152,7 @@ define([
             },
 
             initGraphHelp: function() {
-              labels = '';
+              var labels = '';
               // retrieve the description of each metrics
               this.model.get("metrics").each(function(metric, index) {
                 labels ='<tr>'
@@ -169,7 +162,7 @@ define([
                   + '</td></td>'
                   + labels;
               });
-              help = '<table>'
+              var help = '<table>'
                 + labels
                 + '</table class="stack">'
               // add the hover info
@@ -269,8 +262,8 @@ define([
 
                 // display each new event
                 $.each(changes, function(i) {
-                  change = changes[i];
-                  txt = Message.format_config_change(change);
+                  var change = changes[i];
+                  var txt = Message.format_config_change(change);
                   self.annotator.add(change["ts"], txt);
                 })
                 this.annotator.update();


### PR DESCRIPTION
There are some graphs which are using 2 different units, but using the same scale which is not comparable (on absolute values).
E.g. we have millions of index/sec scans but the ratio is always 0-100% -> ratio is completely hidden (when not selecting the ratio series only)
 
I appended some examples...But I'll add more charts with our live values the next days as there the impact might be more visible. But I'd like to get more feedback if there are more cases to keep in mind. I still set minY to 0 as I think that is looking still better and is more comparable.
 
Before:
![query_before](https://user-images.githubusercontent.com/1894271/86830895-8b205200-c096-11ea-9b5a-b508c900b40b.png)
After:
![query_after](https://user-images.githubusercontent.com/1894271/86830930-93788d00-c096-11ea-97e2-9e8aec112e57.png)

Second example:
Before:
![access_before](https://user-images.githubusercontent.com/1894271/86831037-af7c2e80-c096-11ea-88b3-5319bc9b516c.png)
After:
![access_after](https://user-images.githubusercontent.com/1894271/86831048-b30fb580-c096-11ea-84e9-03312aabeb17.png)
