### PR TITLE
Update copyright to 2020

### DIFF
--- a/powa/templates/layout.html
+++ b/powa/templates/layout.html
@@ -111,7 +111,7 @@
             <ul class="inline-list ">
               <li>Version {{version()}}</li>
               <li>&copy; 2014-2017 Dalibo</li>
-              <li>&copy; 2018-2019 The PoWA-team</li>
+              <li>&copy; 2018-2020 The PoWA-team</li>
               <li><a href="https://powa.readthedocs.io">https://powa.readthedocs.io</a></li>
             </ul>
           </div>


### PR DESCRIPTION
The web UI still shows a copyright to 2019. Update it to 2020.