### PR TITLE
Add join clause on srvid when joining with powa_statements.

### DIFF
--- a/powa/database.py
+++ b/powa/database.py
@@ -341,6 +341,7 @@ class ByQueryMetricGroup(MetricGroupDef):
                    sum(c.blk_read_time).label("blks_read_time"),
                    sum(c.blk_write_time).label("blks_write_time")]
         from_clause = inner_query.join(ps,
+                                       (ps.c.srvid == c.srvid) &
                                        (ps.c.queryid == c.queryid) &
                                        (ps.c.userid == c.userid) &
                                        (ps.c.dbid == c.dbid))
@@ -383,6 +384,7 @@ class ByQueryWaitSamplingMetricGroup(MetricGroupDef):
                    c.event,
                    sum(c.count).label("counts")]
         from_clause = inner_query.join(ps,
+                                       (ps.c.srvid == c.srvid) &
                                        (ps.c.queryid == c.queryid) &
                                        (ps.c.dbid == c.dbid))
         return (select(columns)

--- a/powa/query.py
+++ b/powa/query.py
@@ -466,6 +466,7 @@ class WaitSamplingList(MetricGroupDef):
                    c.event,
                    sum(c.count).label("counts")]
         from_clause = inner_query.join(ps,
+                                       (ps.c.srvid == c.srvid) &
                                        (ps.c.queryid == c.queryid) &
                                        (ps.c.dbid == c.dbid))
         return (select(columns)


### PR DESCRIPTION
Several queries are built from powa_get<something>data_detailed_db by
passing srvid. Later we join with powa_statements but join on srvid was
missing which often lead to a seqscan on powa_statements.

Thanks to join on srvid we can use powa_statements PK.