### PR TITLE
Fix copyright year in footer

### DIFF
--- a/powa/templates/layout.html
+++ b/powa/templates/layout.html
@@ -111,7 +111,7 @@
             <ul class="inline-list ">
               <li>Version {{version()}}</li>
               <li>&copy; 2014-2017 Dalibo</li>
-              <li>&copy; 2018-2020 The PoWA-team</li>
+              <li>&copy; 2018-{{year()}} The PoWA-team</li>
               <li><a href="https://powa.readthedocs.io">https://powa.readthedocs.io</a></li>
             </ul>
           </div>

--- a/powa/ui_methods.py
+++ b/powa/ui_methods.py
@@ -2,6 +2,7 @@
 Set of helper functions available from the templates.
 """
 
+from datetime import datetime
 from powa import __VERSION__
 from powa.json import JSONEncoder
 from tornado.options import options
@@ -17,6 +18,14 @@ def version(_):
         the current powa version.
     """
     return __VERSION__
+
+
+def year(_):
+    """
+    Returns:
+        the current year.
+    """
+    return datetime.now().year
 
 
 def servers(_):


### PR DESCRIPTION
Hi,

I noticed that the copyright statement at the bottom is still saying 2020. This PR fixes that by just showing the current year, which has the benefit of no further work in upcoming years.

Cheers,
Christoph