### PR TITLE
login serverlist with <datalist>...</datalist>

### DIFF
--- a/powa/templates/login.html
+++ b/powa/templates/login.html
@@ -7,11 +7,12 @@
       <form method="POST" action="">
           {% apply field(name="username", label=_("Username")) %}{% end %}
           {% apply field(name="password", label=_("Password"), type="password") %}{% end %}
-          {% apply field(name="server", label=_("Server"), tag="select") %}
+	  {% apply field(name="server", label=_("Server"), list="serverlist") %}{% end %}
+	  <datalist id="serverlist">
             {% for opt in sorted(servers().keys()) %}
-            <option value="{{opt}}">{{opt}}</option>
+            <option value="{{opt}}"></option>
             {% end %}
-          {% end %}
+          </datalist>
           <div class="columns large-12 text-center">
             <input type="submit" name="login" class="button" id="Login" value="Login"/>
           </div>


### PR DESCRIPTION
The server dropdown on login page is sorted by the whole text.
In a huge postgres environment it is usefull to search for server and clusters (and project). 
To have this info available for each entry you have to concat it like "project1, cluster1, server1", "project1, cluster2, server2", "project2, cluster3, server3" ...

The serverlist is sorted by the text of the entries, so it is not easy to find entries by a text which is in the middle of the entries.

All common browsers suport the tag "**datalist**". Together with "**input**" this provides an autocomplete, so you can start typing a word and the option list will contain only the entries mathci with the typed word.

Using this approach the login on huge environments is much more easy.