### PR TITLE
Fix wrong return type for GlobalIoMetricGroup._get_metrics

### DIFF
--- a/powa/io_template.py
+++ b/powa/io_template.py
@@ -63,7 +63,7 @@ class TemplateIoGraph(MetricGroupDef):
         pg_version_num = handler.get_pg_version_num(handler.path_args[0])
         # if we can't connect to the remote server, assume pg15 or less
         if pg_version_num is None or pg_version_num < 160000:
-            return []
+            return {}
         return base
 
     @property


### PR DESCRIPTION
Follow up for 33d71a55f4daf2ed95f4