### PR TITLE
Fix svg not displayed in Graph title on firefox

### DIFF
--- a/powa/static/styles/main.scss
+++ b/powa/static/styles/main.scss
@@ -54,6 +54,11 @@ td {
     color: inherit !important;
 }
 
+.v-icon.v-icon::after {
+    font-size: 1.5em;
+    transform: none;
+}
+
 .v-application{
   background: var(--v-mainbg-base);
 }


### PR DESCRIPTION
As sugested in https://github.com/vuetifyjs/vuetify/issues/12229#issuecomment-888484775 It's solved in vuetify3.