### PR TITLE
Don't reset handlerConfig when load new dashboard config

### DIFF
--- a/powa/static/js/App.vue
+++ b/powa/static/js/App.vue
@@ -187,7 +187,6 @@ onMounted(() => {
 });
 
 function initDashboard() {
-  store.handlerConfig = {};
   store.dashboardConfig = null;
   // Load dahsboard config from same url but asking for JSON instead of HTML
   d3.json(window.location.href, {


### PR DESCRIPTION
This was leading to a flickr effect on the navigation bar.