### PR TITLE
Make sure toprow headers count match columns for grid

### DIFF
--- a/powa/database.py
+++ b/powa/database.py
@@ -987,38 +987,30 @@ class DatabaseOverview(DashboardPage):
 
         toprow = [{
                        # query
-                       'merge': True
                    }, {
                        # plan time
-                       'merge': True
                    }, {
                        'name': 'Execution',
-                       'merge': False,
                        'colspan': 3
                    }, {
                        'name': 'Blocks',
-                       'merge': False,
                        'colspan': 4,
                    }, {
                        'name': 'Temp blocks',
-                       'merge': False,
                        'colspan': 2
                    }, {
                        'name': 'I/O Time',
-                       'merge': False,
                        'colspan': 2
                    }]
         if pgss18:
             toprow.extend([{
                        'name': 'WALs',
-                       'merge': False,
                        'colspan': 3
                        }])
 
         if pgss110:
             toprow.extend([{
                        'name': 'JIT',
-                       'merge': False,
                        'colspan': 2
                        }])
         self._dashboard.widgets.extend(

--- a/powa/database.py
+++ b/powa/database.py
@@ -986,6 +986,10 @@ class DatabaseOverview(DashboardPage):
                         metrics=metrics)]]))
 
         toprow = [{
+                       # query
+                       'merge': True
+                   }, {
+                       # plan time
                        'merge': True
                    }, {
                        'name': 'Execution',

--- a/powa/server.py
+++ b/powa/server.py
@@ -1760,32 +1760,24 @@ class ServerOverview(DashboardPage):
 
         toprow = [{
                        # database
-                       'merge': True
                    }, {
                        # plan time
-                       'merge': True
                    }, {
                        'name': 'Execution',
-                       'merge': False,
                        'colspan': 3
                    }, {
                        'name': 'Blocks',
-                       'merge': False,
                        'colspan': 4,
                    }, {
                        'name': 'Temp blocks',
-                       'merge': False,
                        'colspan': 2
                    }, {
                        'name': 'I/O',
-                       'merge': False,
                    }, {
                        'name': 'WAL',
-                       'merge': False,
                        'colspan': 3
                    }, {
                        'name': 'JIT',
-                       'merge': False,
                        'colspan': 2
                    }]
         dashes = [graphs,

--- a/powa/server.py
+++ b/powa/server.py
@@ -1759,6 +1759,10 @@ class ServerOverview(DashboardPage):
                         metrics=metrics)]]))
 
         toprow = [{
+                       # database
+                       'merge': True
+                   }, {
+                       # plan time
                        'merge': True
                    }, {
                        'name': 'Execution',

--- a/powa/static/js/components/dynamic/Grid.vue
+++ b/powa/static/js/components/dynamic/Grid.vue
@@ -54,7 +54,6 @@
         <template v-if="props.config.toprow" #header>
           <thead>
             <tr>
-              <th></th>
               <th
                 v-for="group in props.config.toprow"
                 :key="group.name"


### PR DESCRIPTION
Previously we were expecting the first column not to be provided and to be taken into account in the UI. We now explicitely set it server side.