### PR TITLE
Introduce a .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# This requires git 2.23 or later.
+#
+# You need to configure git to use this file, with something like:
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Introduction of ruff
+ecb8013b5f3287b51d00a4d7bf9e186cf1336b85


### PR DESCRIPTION
It for now only contains the latest commit reference, which modified a lot of lines without any functional change.

There might be some existing commit that would benefit from being in this file too, but it will be taken care of later if that's the case.