### PR TITLE
Fix version error message when building package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ __VERSION__ = None
 with open("powa/__init__.py") as f:
     for line in f:
         if line.startswith("__VERSION__"):
-            __VERSION__ = line.split("=")[1].replace("'", "").strip()
+            __VERSION__ = line.split("=")[1].replace('"', "").strip()
 
 
 requires = ["tornado>=2.0", "psycopg2"]


### PR DESCRIPTION
After the commit ecb8013b5f in which we changed the way the python code is formatted, the "hack" to get the version in setup.py no longer worked.

The current commit fixes this. A better management of the version should be implemented. For example, using setuptools_scm could be a good option.

Related to #218 