### PR TITLE
Don't fail on SQL format errors

### DIFF
--- a/powa/static/js/utils/sql.js
+++ b/powa/static/js/utils/sql.js
@@ -6,6 +6,11 @@ import { formatDialect, postgresql } from "sql-formatter";
 hljs.registerLanguage("sql", pgsql);
 
 export function formatSql(value) {
-  value = formatDialect(value, { dialect: postgresql });
-  return hljs.highlightAuto(value, ["sql"]).value;
+  try {
+    value = formatDialect(value, { dialect: postgresql });
+    value = hljs.highlightAuto(value, ["sql"]).value;
+  } catch (error) {
+    console.error("Could not highlight SQL:", value);
+  }
+  return value;
 }


### PR DESCRIPTION
For example, with the following query the SQL formatter / highlighter raises an error:
``` SQL
SELECT id AS srvid,
                CASE WHEN id = $1 THEN
                   $2
                ELSE
                   COALESCE(alias, hostname || $3 || port)
                END AS alias,
                CASE WHEN id = $4 THEN $5 ELSE hostname END as hostname,
                CASE WHEN id = $6 THEN $7 ELSE port END AS port,
                CASE WHEN id = $8 THEN set.setting
                    ELSE s.version::text
                END AS version
                FROM public.powa_servers s
                LEFT JOIN pg_settings set ON set.name = $9
                    AND s.id = $10
```

Until this can be fixed in the library and in order to prevent PoWA to work improperly (navigation broken), we catch the error and show the unhighlighted value.