### PR TITLE
fix: Fix notifiation authorization check on pg13-

### DIFF
--- a/powa/dashboards.py
+++ b/powa/dashboards.py
@@ -152,7 +152,7 @@ class DashboardHandler(AuthHandler):
         try:
             cur.execute(
                 """WITH s(v) AS (
-                    SELECT unnest(%s)
+                    SELECT unnest(%s::text[])
                     UNION ALL
                     SELECT rolname
                     FROM {powa}.powa_roles


### PR DESCRIPTION
Postgres 13 or lower don't have predefined roles, so we call unnest on an empty python array which is emitted as '{}'.  This is ambiguous for postgres so we need to explicitly cast the value as an array of text, which works for both an empty array and a non empty array (which is emitted as ARRAY[...]).