### PR TITLE
fix: Fix pg_stat_archiver on pg13-

### DIFF
--- a/powa/server.py
+++ b/powa/server.py
@@ -722,10 +722,11 @@ class GlobalArchiverMetricGroup(MetricGroupDef):
     @property
     def query(self):
         query = powa_get_archiver_sample()
+        ts = get_ts()
 
         cols = [
             "extract(epoch FROM ts) AS ts",
-            "round(nb_arch::numeric / " + get_ts() + ", 2) AS nb_arch",
+            "round((nb_arch::numeric / " + ts + ")::numeric, 2) AS nb_arch",
             "nb_to_arch",
         ]
 


### PR DESCRIPTION
On older postgres version the existing cast to numeric isn't enough to guarantee that the result expression is numeric too, so explicitly cast the resulting expression to numeric to make sure that we can round the result.