### PR TITLE
fix debian packaging: add missing dist files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,6 @@ exclude powa/templates/
 recursive-include powa/templates *.html
 recursive-include  powa/static/css *
 recursive-include  powa/static/img *
-include powa/static/js/powa.min-all.js
-include powa/static/js/config.js
-include powa/static/js/require.js
+recursive-include  powa/static/dist *
 include powa/powa.wsgi
 include powa-web.conf-dist


### PR DESCRIPTION
we build a internal debian package for powa-web which fails with the current Manifest.in file, as it does not take the new directory structure into account

```
python3 setup.py --command-packages=stdeb.command bdist_deb
...
warning: no previously-included files found matching 'powa/templates/'
warning: no files found matching '*' under directory 'powa/static/css'
warning: no files found matching 'powa/static/js/powa.min-all.js'
warning: no files found matching 'powa/static/js/config.js'
warning: no files found matching 'powa/static/js/require.js'
writing manifest file 'powa_web.egg-info/SOURCES.txt'
...
```
and there are not dist files in the debian package, so no UI at all :( 