### PR TITLE
Format more files with Ruff

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,5 @@
 line-length = 79
+extend-include = ["powa-web", "powa/powa.wsgi"]
 
 [lint]
 # Default `select` is: "E4", "E7", "E9", "F"

--- a/powa-web
+++ b/powa-web
@@ -1,24 +1,30 @@
 #!/usr/bin/env python
+import logging
 import os
 import sys
-from powa import make_app
 import tornado.ioloop
-import logging
+from powa import make_app
 from tornado.options import options
 
 if __name__ == "__main__":
     application = make_app(debug=False, gzip=True, compress_response=True)
     logger = logging.getLogger("tornado.application")
 
-    if (options.certfile and not options.keyfile or
-            not options.certfile and options.keyfile):
-        logger.error("Invalid SSL configuration: you need to provide both "
-                     "certfile and keyfile")
+    if (
+        options.certfile
+        and not options.keyfile
+        or not options.certfile
+        and options.keyfile
+    ):
+        logger.error(
+            "Invalid SSL configuration: you need to provide both "
+            "certfile and keyfile"
+        )
         sys.exit(1)
 
     server = application
     protocol = "http"
-    if (options.certfile and options.keyfile):
+    if options.certfile and options.keyfile:
         if not os.path.isfile(options.certfile):
             logger.error("Certificate file %s not found", options.certfile)
             sys.exit(1)
@@ -27,14 +33,20 @@ if __name__ == "__main__":
             sys.exit(1)
 
         ssl_options = {
-                'certfile': options.certfile,
-                'keyfile': options.keyfile,
+            "certfile": options.certfile,
+            "keyfile": options.keyfile,
         }
-        server = tornado.httpserver.HTTPServer(application,
-                                               ssl_options=ssl_options)
+        server = tornado.httpserver.HTTPServer(
+            application, ssl_options=ssl_options
+        )
         protocol = "https"
 
     server.listen(options.port, address=options.address)
-    logger.info("Starting powa-web on %s://%s:%s%s",
-                protocol, options.address, options.port, options.url_prefix)
+    logger.info(
+        "Starting powa-web on %s://%s:%s%s",
+        protocol,
+        options.address,
+        options.port,
+        options.url_prefix,
+    )
     tornado.ioloop.IOLoop.instance().start()

--- a/powa/powa.wsgi
+++ b/powa/powa.wsgi
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
-from powa import make_app
 import sys
 import tornado
+from powa import make_app
 
-if tornado.version > '4':
+if tornado.version > "4":
     from tornado.wsgi import WSGIAdapter
+
     application = make_app(debug=False, gzip=True, compress_response=True)
     application = WSGIAdapter(application)
 else:
@@ -12,8 +13,8 @@ else:
     # implement isatty for the log file, and certain versions
     # of tornado don't check for the existence of isatty
     if not hasattr(sys.stderr, "isatty"):
-        class StdErrWrapper(object):
 
+        class StdErrWrapper(object):
             def __init__(self, wrapped):
                 super(StdErrWrapper, self).__setattr__("wrapped", wrapped)
 
@@ -29,4 +30,6 @@ else:
                 return setattr(self.wrapped, att, value)
 
         sys.stderr = StdErrWrapper(sys.stderr)
-    application = make_app(debug=False, gzip=True, compress_response=True, legacy_wsgi=True)
+    application = make_app(
+        debug=False, gzip=True, compress_response=True, legacy_wsgi=True
+    )


### PR DESCRIPTION
powa-web and powa.wsgi were not checked by Ruff because the extension for those files don't match default inclusions.