### PR TITLE
Fix the sampling of the pgsa query

### DIFF
--- a/powa/sql/views_graph.py
+++ b/powa/sql/views_graph.py
@@ -517,9 +517,9 @@ def BASE_QUERY_PGSA_SAMPLE(per_db=False):
 
     # We use dense_rank() as we need ALL the records for a specific ts
     return """
+    (SELECT *,max(number) OVER () AS total FROM
     (SELECT pgsa_history.srvid,
       dense_rank() OVER (ORDER BY pgsa_history.ts) AS number,
-      count(*) OVER () AS total,
       ts,
       datid,
       cur_txid,
@@ -548,7 +548,7 @@ def BASE_QUERY_PGSA_SAMPLE(per_db=False):
         AND (record).backend_type <> 'autovacuum worker'
       ) AS pgsa_history
       {extra}
-    ) AS pgsa
+    ) AS temp) AS pgsa
     WHERE number %% ( int8larger((total)/(%(samples)s+1),1) ) = 0
 """.format(extra=extra)
 


### PR DESCRIPTION
It wrongly computes the sampling: the "total" column is not correct in this context: we (most of the time) have more than 1 record per sample. If you have 100 sessions, the sampling will be off by a factor of 100, and you'll end up with only 1 sample

It's a bit ugly to fix, because we need another subquery...

Closes #254