### PR TITLE
Improve powa_wait_sampling_history query

### DIFF
--- a/powa/sql/views_grid.py
+++ b/powa/sql/views_grid.py
@@ -578,7 +578,7 @@ def powa_base_waitdata_detailed_db():
       SELECT wsh.dbid, wsh.queryid, wsh.event_type, wsh.event,
         wsh.coalesce_range, unnest(records) AS records
       FROM {powa}.powa_wait_sampling_history wsh
-      WHERE coalesce_range && tstzrange(%(from)s, %(to)s, '[]')
+      WHERE coalesce_range && tstzrange(%(from)s, %(from)s, '[]')
       AND wsh.dbid = powa_databases.oid
       -- we can't simply join powa_statements as there's no userid in
       -- powa_wait_sampling_* tables


### PR DESCRIPTION
There is a bug: the result is still ok, but it's a performance issue

The left boundary query for powa_base_waitdata_detailed_db on the interval is wrong: the matching interval should be from/from (see other queries that do the same manipulation). So we're doing twice the full interval of the query, once for nothing (and we redo the comparisons on the unnested records on this large one, which takes lots of cpu)