### PR TITLE
Do not display autovacuum workers in the sessions graphs

### DIFF
--- a/powa/database.py
+++ b/powa/database.py
@@ -368,7 +368,7 @@ class DatabasePGSAOverview(MetricGroupDef):
 
     name = "pgsa"
     xaxis = "ts"
-    desc = "All backends, including autovacuum workers, are included"
+    desc = "All backends, except autovacuum workers, are included"
     data_url = r"/server/(\d+)/metrics/pgsa_overview/([^\/]+)/"
     backend_xid_age = MetricDef(label="Backend xid age")
     backend_xmin_age = MetricDef(label="Backend xmin age")

--- a/powa/database.py
+++ b/powa/database.py
@@ -1082,7 +1082,7 @@ class DatabaseOverview(DashboardPage):
         db_graphs.append(
             [
                 Graph(
-                    "Global activity (On database %(database)s, except autovacuum)",
+                    "Global activity (On database %(database)s)",
                     metrics=pgsa_metrics[0],
                     renderer="bar",
                     stack=True,

--- a/powa/database.py
+++ b/powa/database.py
@@ -1082,7 +1082,7 @@ class DatabaseOverview(DashboardPage):
         db_graphs.append(
             [
                 Graph(
-                    "Global activity (On database %(database)s)",
+                    "Global activity (On database %(database)s, except autovacuum)",
                     metrics=pgsa_metrics[0],
                     renderer="bar",
                     stack=True,

--- a/powa/database.py
+++ b/powa/database.py
@@ -1084,6 +1084,7 @@ class DatabaseOverview(DashboardPage):
                 Graph(
                     "Global activity (On database %(database)s)",
                     metrics=pgsa_metrics[0],
+                    desc=DatabasePGSAOverview.desc,
                     renderer="bar",
                     stack=True,
                 )

--- a/powa/server.py
+++ b/powa/server.py
@@ -1853,7 +1853,7 @@ class ServerOverview(DashboardPage):
                 Graph(
                     "Global activity (all databases)",
                     metrics=pgsa_metrics[0],
-                    desc=desc=GlobalPGSAMetricGroup.desc,
+                    desc=GlobalPGSAMetricGroup.desc,
                     renderer="bar",
                     stack=True,
                 )

--- a/powa/server.py
+++ b/powa/server.py
@@ -1853,6 +1853,7 @@ class ServerOverview(DashboardPage):
                 Graph(
                     "Global activity (all databases)",
                     metrics=pgsa_metrics[0],
+                    desc=desc=GlobalPGSAMetricGroup.desc,
                     renderer="bar",
                     stack=True,
                 )

--- a/powa/server.py
+++ b/powa/server.py
@@ -1851,7 +1851,7 @@ class ServerOverview(DashboardPage):
         all_db_graphs.append(
             [
                 Graph(
-                    "Global activity (all databases)",
+                    "Global activity (all databases, except autovacuum)",
                     metrics=pgsa_metrics[0],
                     renderer="bar",
                     stack=True,

--- a/powa/server.py
+++ b/powa/server.py
@@ -1851,7 +1851,7 @@ class ServerOverview(DashboardPage):
         all_db_graphs.append(
             [
                 Graph(
-                    "Global activity (all databases, except autovacuum)",
+                    "Global activity (all databases)",
                     metrics=pgsa_metrics[0],
                     renderer="bar",
                     stack=True,

--- a/powa/server.py
+++ b/powa/server.py
@@ -639,7 +639,7 @@ class GlobalPGSAMetricGroup(MetricGroupDef):
 
     name = "pgsa"
     xaxis = "ts"
-    desc = "All backends, including autovacuum workers, are included"
+    desc = "All backends, excluding autovacuum workers, are included"
     data_url = r"/server/(\d+)/metrics/pgsa/"
     backend_xid_age = MetricDef(label="Backend xid age")
     backend_xmin_age = MetricDef(label="Backend xmin age")

--- a/powa/sql/views_graph.py
+++ b/powa/sql/views_graph.py
@@ -511,9 +511,10 @@ def BASE_QUERY_PGSA_SAMPLE(per_db=False):
     if per_db:
         extra = """JOIN {powa}.powa_catalog_databases d
             ON d.oid = pgsa_history.datid and d.srvid = pgsa_history.srvid
-        WHERE d.datname = %(database)s"""
+        WHERE d.datname = %(database)s
+      AND backend_type <> 'autovacuum worker'"""
     else:
-        extra = ""
+        extra = "WHERE backend_type <> 'autovacuum worker'"
 
     # We use dense_rank() as we need ALL the records for a specific ts
     return """
@@ -546,7 +547,6 @@ def BASE_QUERY_PGSA_SAMPLE(per_db=False):
         AND pgsac.srvid = %(server)s
       ) AS pgsa_history
       {extra}
-      AND backend_type <> 'autovacuum worker'
     ) AS pgsa
     WHERE number %% ( int8larger((total)/(%(samples)s+1),1) ) = 0
 """.format(extra=extra)

--- a/powa/sql/views_graph.py
+++ b/powa/sql/views_graph.py
@@ -546,6 +546,7 @@ def BASE_QUERY_PGSA_SAMPLE(per_db=False):
         AND pgsac.srvid = %(server)s
       ) AS pgsa_history
       {extra}
+      AND backend_type <> 'autovacuum worker'
     ) AS pgsa
     WHERE number %% ( int8larger((total)/(%(samples)s+1),1) ) = 0
 """.format(extra=extra)


### PR DESCRIPTION
I think it makes sense to keep them only on the vacuum graphs (database objects view)

Without this, we get very long "transactions" and xids displayed in the main graph, and it's confusing