### PR TITLE
Add a new optional graph description

### DIFF
--- a/powa/dashboards.py
+++ b/powa/dashboards.py
@@ -526,9 +526,11 @@ class Graph(Widget):
         url=None,
         axistype="time",
         metrics=None,
+        desc=None,
         **kwargs,
     ):
         self.title = title
+        self.desc = desc
         self.url = url
         self.grouper = grouper
         self.metrics = metrics or []

--- a/powa/database.py
+++ b/powa/database.py
@@ -368,6 +368,7 @@ class DatabasePGSAOverview(MetricGroupDef):
 
     name = "pgsa"
     xaxis = "ts"
+    desc = "All backends, including autovacuum workers, are included"
     data_url = r"/server/(\d+)/metrics/pgsa_overview/([^\/]+)/"
     backend_xid_age = MetricDef(label="Backend xid age")
     backend_xmin_age = MetricDef(label="Backend xmin age")
@@ -1099,6 +1100,7 @@ class DatabaseOverview(DashboardPage):
             Graph(
                 "Backend age (On database %(database)s)",
                 metrics=pgsa_metrics[1],
+                desc=DatabasePGSAOverview.desc,
             )
         )
 

--- a/powa/server.py
+++ b/powa/server.py
@@ -639,6 +639,7 @@ class GlobalPGSAMetricGroup(MetricGroupDef):
 
     name = "pgsa"
     xaxis = "ts"
+    desc = "All backends, including autovacuum workers, are included"
     data_url = r"/server/(\d+)/metrics/pgsa/"
     backend_xid_age = MetricDef(label="Backend xid age")
     backend_xmin_age = MetricDef(label="Backend xmin age")
@@ -1864,7 +1865,11 @@ class ServerOverview(DashboardPage):
                 )
             )
         all_db_graphs[1].append(
-            Graph("Backend age (all databases)", metrics=pgsa_metrics[1])
+            Graph(
+                "Backend age (all databases)",
+                metrics=pgsa_metrics[1],
+                desc=GlobalPGSAMetricGroup.desc,
+            )
         )
 
         graphs_dash = [Dashboard("General Overview", all_db_graphs)]

--- a/powa/static/js/components/dynamic/Graph.vue
+++ b/powa/static/js/components/dynamic/Graph.vue
@@ -25,9 +25,9 @@
             ></v-icon>
           </template>
           <div>
-            <p v-if="config.desc">
+            <v-alert v-if="config.desc" class="ma-2 pa-3 ps-6">
               {{ config.desc }}
-            </p>
+            </v-alert>
             <dl>
               <div v-for="metric in chosenMetrics" :key="metric">
                 <dt>

--- a/powa/static/js/components/dynamic/Graph.vue
+++ b/powa/static/js/components/dynamic/Graph.vue
@@ -25,6 +25,9 @@
             ></v-icon>
           </template>
           <div>
+            <p v-if="config.desc">
+              {{ config.desc }}
+            </p>
             <dl>
               <div v-for="metric in chosenMetrics" :key="metric">
                 <dt>


### PR DESCRIPTION
Graph() accepts a new optional "desc" parameter.  If provided, it will be included in the hover help before the per-metric description.

As an example, the "Backend age" graphs now mention that autovacuum worker are included in the graph as this should be modified soon.