### PR TITLE
Rely on powa_databases rather than powa_catalog_databases

### DIFF
--- a/powa/sql/views_graph.py
+++ b/powa/sql/views_graph.py
@@ -509,7 +509,7 @@ BASE_QUERY_WAIT_SAMPLE = """(
 # the highest transaction id is 2^32.
 def BASE_QUERY_PGSA_SAMPLE(per_db=False):
     if per_db:
-        extra = """JOIN {powa}.powa_catalog_databases d
+        extra = """JOIN {powa}.powa_databases d
             ON d.oid = pgsa_history.datid and d.srvid = pgsa_history.srvid
         WHERE d.datname = %(database)s"""
     else:
@@ -645,7 +645,7 @@ BASE_QUERY_CHECKPOINTER_SAMPLE = """
 
 def BASE_QUERY_DATABASE_SAMPLE(per_db=False):
     if per_db:
-        extra = """JOIN {powa}.powa_catalog_databases d
+        extra = """JOIN {powa}.powa_databases d
             ON d.oid = psd_history.datid and d.srvid = psd_history.srvid
         WHERE d.datname = %(database)s"""
     else:
@@ -706,7 +706,7 @@ def BASE_QUERY_DATABASE_SAMPLE(per_db=False):
 
 def BASE_QUERY_DATABASE_CONFLICTS_SAMPLE(per_db=False):
     if per_db:
-        extra = """JOIN {powa}.powa_catalog_databases d
+        extra = """JOIN {powa}.powa_databases d
             ON d.oid = psd_history.datid and d.srvid = psd_history.srvid
         WHERE d.datname = %(database)s"""
     else:

--- a/powa/sql/views_grid.py
+++ b/powa/sql/views_grid.py
@@ -938,8 +938,8 @@ def powa_getuserfuncdata_detailed_db(funcid=None):
         groupby.extend(["prosrc", "last_refresh"])
 
     if funcid:
-        join_db = """LEFT JOIN {powa}.powa_catalog_databases pcd
-            ON pcd.srvid = d.srvid AND pcd.oid = h.dbid"""
+        join_db = """INNER JOIN {powa}.powa_databases pd
+            ON pd.srvid = d.srvid AND pd.oid = h.dbid"""
         and_funcid = "AND funcid = {funcid}".format(funcid=funcid)
     else:
         join_db = ""


### PR DESCRIPTION
The catalog tables are not refreshed very often (the default is every month), so we shouldn't rely on them when displaying information that doesn't also come from the catalogs.