### PR TITLE
Support dynamic address and port un run_powa.py

### DIFF
--- a/run_powa.py
+++ b/run_powa.py
@@ -6,9 +6,12 @@ from tornado.options import options
 
 if __name__ == "__main__":
     application = make_app(debug=True, gzip=True, compress_response=True)
-    application.listen(8888)
+    application.listen(options.port, address=options.address)
     logger = logging.getLogger("tornado.application")
     logger.info(
-        "Starting powa-web on http://127.0.0.1:8888%s", options.url_prefix
+        "Starting powa-web on http://%s:%s%s",
+        options.address,
+        options.port,
+        options.url_prefix,
     )
     tornado.ioloop.IOLoop.instance().start()


### PR DESCRIPTION
This script is only meant for development, but it's still confusing that it ignores the configured listening address and port especially especially since needing different values than the hardcoded ones is a common need.