### PR TITLE
Properly detect missing extensions

### DIFF
--- a/powa/framework.py
+++ b/powa/framework.py
@@ -87,8 +87,11 @@ class CustomCursor(_cursor):
 
 
 def resolve_nsps(query, connection):
-    if hasattr(connection, "_nsps"):
-        return query.format(**connection._nsps)
+    try:
+        if hasattr(connection, "_nsps"):
+            return query.format(**connection._nsps)
+    except KeyError as e:
+        raise Exception("Extension not found: " + e.args[0])
 
     return query
 
@@ -254,7 +257,12 @@ class BaseHandler(RequestHandler, JSONizable):
             WHERE extname = 'powa'
             """,
             **kwargs,
-        )[0]["version"]
+        )
+
+        if len(version) == 0:
+            return None
+
+        version = version[0]["version"]
         if version is None:
             return None
         return [int(part) for part in version.split(".")]


### PR DESCRIPTION
If the powa-extension is not installed on the repository server, login should fail and the UI should report an error message.  Unfortunately the existing logic was broken as the underlying function was throwing an exception rather than returning an expected None if the powa extension is not installed.  This commit fixes this case and properly return None.

While at it, report a better error if one of the needed extension is not installed on the repository server.  An internal error stack is still displayed, but at least it will show an informative "extenion not found" with the associated extension name rather than an obscure "key error" message.