### PR TITLE
Use the newly introduced "clock_ts" column

### DIFF
--- a/powa/sql/views_graph.py
+++ b/powa/sql/views_graph.py
@@ -1331,7 +1331,7 @@ def powa_get_pgsa_sample(per_db=False):
 
     def ts_get_sec(field):
         alias = field + "_age"
-        return """extract(epoch FROM (ts - {f})) * 1000 AS {a}""".format(
+        return """extract(epoch FROM (coalesce(clock_ts, ts) - {f})) * 1000 AS {a}""".format(
             f=field, a=alias
         )
 


### PR DESCRIPTION
powa-archivist 3.1.0 added a new "clocl_ts" column in the pg_stat_activity related tables, to compute more precise age metrics.  There is no guarantee that this column is valued if the extension was just upgraded, so fallback on the previous "ts" column when needed.