### PR TITLE
Fix pg19+ pg_stat_subscription_stats compatibility

### DIFF
--- a/powa/server.py
+++ b/powa/server.py
@@ -1068,11 +1068,11 @@ class GlobalSubMetricGroup(MetricGroupDef):
         type="number",
         desc="Total number of times an error occurred while applying changes",
     )
-    sync_error_count = MetricDef(
-        label="# sync error",
+    sync_table_error_count = MetricDef(
+        label="# table sync error",
         type="number",
         desc="Total number of times an error"
-        " occurred during the inital table"
+        " occurred during the initial table"
         " synchronization",
     )
 
@@ -1093,7 +1093,7 @@ class GlobalSubMetricGroup(MetricGroupDef):
             return {}
         elif pg_version_num < 150000:
             base.pop("apply_error_count")
-            base.pop("sync_error_count")
+            base.pop("sync_table_error_count")
 
         return base
 
@@ -1109,7 +1109,7 @@ class GlobalSubMetricGroup(MetricGroupDef):
             "max(last_msg_lag) AS last_msg_lag",
             "max(report_lag) AS report_lag",
             "sum(apply_error_count) AS apply_error_count",
-            "sum(sync_error_count) AS sync_error_count",
+            "sum(sync_table_error_count) AS sync_table_error_count",
         ]
 
         return """SELECT {cols}

--- a/powa/sql/views_graph.py
+++ b/powa/sql/views_graph.py
@@ -928,7 +928,7 @@ def BASE_QUERY_SUBSCRIPTION_SAMPLE(subname=None):
       latest_end_lsn,
       extract(epoch FROM ((ts - latest_end_time) * 1000)) AS report_lag,
       apply_error_count,
-      sync_error_count
+      sync_table_error_count
       FROM (
         SELECT *
         FROM (
@@ -1609,7 +1609,7 @@ def powa_get_subscription_sample(subname=None):
         biggest("last_msg_lag"),
         biggest("report_lag"),
         biggest("apply_error_count"),
-        biggest("sync_error_count"),
+        biggest("sync_table_error_count"),
     ]
 
     return """SELECT {all_cols}


### PR DESCRIPTION
The sync_error_count column was renamed to sync_table_error_count, and that change is reflected in the powa-archivist column so apply the same renaming here too.

Note that more columns were also added to that view in pg19, but this will be handled in a later commit.