### PR TITLE
Start working on v5.3.0

### DIFF
--- a/powa/__init__.py
+++ b/powa/__init__.py
@@ -7,7 +7,7 @@ Powa main application.
 import os
 import re
 
-__VERSION__ = "5.2.0"
+__VERSION__ = "5.3.0dev"
 
 ver_tmp = re.sub(r"(alpha|beta|dev)[0-9]*", "", __VERSION__)
 __VERSION_NUM__ = [int(part) for part in (ver_tmp.split("."))]


### PR DESCRIPTION
Upstream made a mistake in one of the new views defintion, which is fixed in pg19beta2.  Since this is compatibility break we have to use a new major version.